### PR TITLE
Fixed bug: send notifications even if title not specified

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -150,20 +150,25 @@ exports.notify = function(msg, options, fn) {
       args.push('--name', options.name);
     }
 
-    // title
-    if (options.title) {
-      switch(cmd.type) {
-        case 'Darwin':
-          args.push(cmd.msg);
-          args.push('"' + msg + '"');
+    switch(cmd.type) {
+      case 'Darwin':
+        args.push(cmd.msg);
+        args.push('"' + msg + '"');
+        // title
+        if (options.title) {
           args.push(options.title);
-          break;
-        case 'Linux':
+        }
+        break;
+      case 'Linux':
+        // title
+        if (options.title) {
           args.push("'" + options.title + "'");
           args.push(cmd.msg);
           args.push("'" + msg + "'");
-          break;
-      }
+        } else {
+          args.push("'" + msg + "'");
+        }
+        break;
     }
 
     // execute


### PR DESCRIPTION
Now it'll send the notification even it the title is not specified.

Note: I have tested on Ubuntu and works great, please test on Mac also.
