### PR TITLE
Fail silently on non-osx / linux.

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -1,4 +1,3 @@
-
 // Growl - Copyright TJ Holowaychuk <tj@vision-media.ca> (MIT Licensed)
 
 /**
@@ -95,12 +94,13 @@ exports.version = '1.4.1'
 
 function growl(msg, options, fn) {
   var image
-    , args = [cmd.pkg]
+    , args
     , options = options || {}
     , fn = fn || function(){};
 
   // noop
   if (!cmd) return fn(new Error('growl not supported on this platform'));
+  args = [cmd.pkg];
 
   // image
   if (image = options.image) {


### PR DESCRIPTION
Currently calling `growl()` on unsupported platforms throws TypeError. The patch fixes it.
