### PR TITLE
Hi. I have updated growl.js to support Windows.

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -140,7 +140,7 @@ function growl(msg, options, fn) {
         args.push(cmd.icon + image);
         break;
       case 'Windows':
-        args.push(cmd.icon + image);
+        args.push(cmd.icon + '"' + image.replace(/\\/g, "\\\\") + '"');
         break;
     }
   }


### PR DESCRIPTION
I've also added cmd options "icon" and "title" for Windows and also "icon" for Linux.
I have it successfully running under Windows 7.
