### PR TITLE
Fixes #15

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -137,7 +137,7 @@ function growl(msg, options, fn) {
         args.push('--' + flag, image)
         break;
       case 'Linux':
-        args.push(cmd.icon + image);
+        args.push(cmd.icon + " " + image);
         break;
       case 'Windows':
         args.push(cmd.icon + '"' + image.replace(/\\/g, "\\\\") + '"');


### PR DESCRIPTION
Image paths where concatenated to the -i flag without a space in between them causing notifications in Linux to fail.
