### PR TITLE
handle priority reasonably on linux

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -44,7 +44,9 @@ switch(os.type()) {
           cmd: '-u'
         , range: [
             "low"
+          , "low"
           , "normal"
+          , "critical"
           , "critical"
         ]
       }
@@ -151,9 +153,11 @@ function growl(msg, options, fn) {
   // priority
   if (options.priority) {
     var priority = options.priority + '';
-    var checkindexOf = cmd.priority.range.indexOf(priority);
+    var map = cmd.priority.range[options.priority + 2];
     if (~cmd.priority.range.indexOf(priority)) {
-      args.push(cmd.priority, options.priority);
+      args.push(cmd.priority.cmd, options.priority);
+    } else if (map !== undefined) {
+      args.push(cmd.priority.cmd, map);
     }
   }
 


### PR DESCRIPTION
allows using -2 ... 2 parameters for priority. There is still the possibility to use named priorities which are unique to linux or mac, depending.
