### PR TITLE
better escaping for shell commands

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -8,6 +8,7 @@ var exec = require('child_process').exec
   , exists = require('fs').existsSync
   , path = require('path')
   , os = require('os')
+  , quote = JSON.stringify
   , cmd;
 
 function which(name) {
@@ -165,7 +166,7 @@ function growl(msg, options, fn) {
         args.push(cmd.icon + " " + image);
         break;
       case 'Windows':
-        args.push(cmd.icon + '"' + image.replace(/\\/g, "\\\\") + '"');
+        args.push(cmd.icon + quote(image));
         break;
     }
   }
@@ -190,38 +191,38 @@ function growl(msg, options, fn) {
   switch(cmd.type) {
     case 'Darwin-Growl':
       args.push(cmd.msg);
-      args.push('"' + msg + '"');
-      if (options.title) args.push('"' + options.title + '"');
+      args.push(quote(msg));
+      if (options.title) args.push(quote(options.title));
       break;
     case 'Darwin-NotificationCenter':
       args.push(cmd.msg);
-      args.push('"' + msg + '"');
+      args.push(quote(msg));
       if (options.title) {
         args.push(cmd.title);
-        args.push('"' + options.title + '"');
+        args.push(quote(options.title));
       }
       if (options.subtitle) {
         args.push(cmd.subtitle);
-        args.push('"' + options.subtitle + '"');
+        args.push(quote(options.title));
       }
       break;
     case 'Darwin-Growl':
       args.push(cmd.msg);
-      args.push('"' + msg + '"');
-      if (options.title) args.push('"' + options.title + '"');
+      args.push(quote(msg));
+      if (options.title) args.push(quote(options.title));
       break;
     case 'Linux':
       if (options.title) {
-        args.push("'" + options.title + "'");
+        args.push(quote(options.title));
         args.push(cmd.msg);
-        args.push("'" + msg + "'");
+        args.push(quote(msg));
       } else {
-        args.push("'" + msg + "'");
+        args.push(quote(msg));
       }
       break;
     case 'Windows':
-      args.push('"' + msg + '"');
-      if (options.title) args.push(cmd.title + '"' + options.title + '"');
+      args.push(quote(msg));
+      if (options.title) args.push(cmd.title + quote(options.title));
       break;
   }
 

--- a/test.js
+++ b/test.js
@@ -15,3 +15,6 @@ growl('Show pdf filesystem icon', { image: 'article.pdf' }, function(){
   console.log('callback');
 })
 growl('Show pdf filesystem icon', { title: 'Use show()', image: 'article.pdf' })
+growl('here \' are \n some \\ characters that " need escaping', {}, function(error, stdout, stderr) {
+  if (error !== null) throw new Error('escaping failed:\n' + stdout + stderr);
+})


### PR DESCRIPTION
Wrapping the text in single or double quotes doesn't work when the string itself contains quotes or other special characters. This is fixed by using JSON.stringify() to handle the quoting instead.
