### PR TITLE
restore compatibility with node < 0.8

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -5,8 +5,9 @@
  */
 
 var exec = require('child_process').exec
-  , exists = require('fs').existsSync
+  , fs = require('fs')
   , path = require('path')
+  , exists = fs.existsSync || path.existsSync
   , os = require('os')
   , quote = JSON.stringify
   , cmd;


### PR DESCRIPTION
... by falling back to `path.existsSync()`
