### PR TITLE
Lookup growlnotify path on osx < 10.8 so that it can be called from within launchd scripts

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -10,7 +10,8 @@ var exec = require('child_process').exec
   , exists = fs.existsSync || path.existsSync
   , os = require('os')
   , quote = JSON.stringify
-  , cmd;
+  , cmd
+  , pkg;
 
 function which(name) {
   var paths = process.env.PATH.split(':');
@@ -36,10 +37,10 @@ switch(os.type()) {
             , range: []
           }
       };
-    } else {
+    } else if ((pkg = which('growlnotify'))) {
       cmd = {
           type: "Darwin-Growl"
-        , pkg: "growlnotify"
+        , pkg: pkg
         , msg: '-m'
         , sticky: '--sticky'
         , priority: {


### PR DESCRIPTION
Launchd seems to require the full path not just the command name, on osx, so look it up with `which`.
