### PR TITLE
Allow Windows growlnotify to register Applications

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -191,6 +191,12 @@ function growl(msg, options, fn) {
     args.push('--name', options.name);
   }
 
+  if (options.name && cmd.type === "Windows") {
+    args.push('/a:' + quote(options.name));
+    args.push('/r:' + quote('node-growl'));
+    args.push('/n:' + quote('node-growl'));
+  }
+
   switch(cmd.type) {
     case 'Darwin-Growl':
       args.push(cmd.msg);
@@ -224,11 +230,10 @@ function growl(msg, options, fn) {
       }
       break;
     case 'Windows':
-      args.push(quote(msg));
       if (options.title) args.push(cmd.title + quote(options.title));
+      args.push(quote(msg));
       break;
   }
-
   // execute
   exec(args.join(' '), fn);
 };


### PR DESCRIPTION
Sets the proper flags to register a new application in Growl on Windows if options.name is set, as well, registers an event called node-growl. (In case the application already exists.)