### PR TITLE
Adding repository section to package.json to suppress warning from NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,9 @@
   "version": "1.7.0",
   "description": "Growl unobtrusive notifications",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/visionmedia/node-growl.git"
+  },
   "main": "./lib/growl.js"
 }


### PR DESCRIPTION
NPM emits a warning when the repository field is not defined in the `package.json` file:

```
npm WARN package.json growl@1.7.0 No repository field.
```

This pull request adds the repository field. :-)

(Sorry about submitting the same pull to more than one of your repos!)
