### PR TITLE
Fix images failing when they have spaces (OSX)

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -161,7 +161,7 @@ function growl(msg, options, fn) {
         flag = flag || /^png|gif|jpe?g$/.test(ext) && 'image'
         flag = flag || ext && (image = ext) && 'icon'
         flag = flag || 'icon'
-        args.push('--' + flag, image)
+        args.push('--' + flag, quote(image))
         break;
       case 'Linux':
         args.push(cmd.icon + " " + image);


### PR DESCRIPTION
Steps to reproduce the bug:

```
 touch "a b.png"
 npm install growl
 node -e "require('growl')('hi', { image: 'a b.png' })"
```

Confirmed in OSX 10.6.
