### PR TITLE
Fix images failing when they have spaces (Linux)

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -164,7 +164,7 @@ function growl(msg, options, fn) {
         args.push('--' + flag, image)
         break;
       case 'Linux':
-        args.push(cmd.icon + " " + image);
+        args.push(cmd.icon, quote(image));
         // libnotify defaults to sticky, set a hint for transient notifications
         if (!options.sticky) args.push('--hint=int:transient:1');
         break;


### PR DESCRIPTION
Reproduce via:

```
touch "a b.png"
npm install growl
node -e "require('growl')('hi', { image: 'a b.png' })"
```

Haven't tested this (hence the separate PR), but seems fair that it should work.
