### PR TITLE
rendering \n as a newline for Darwin-NotificationCenter implementation

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -199,7 +199,9 @@ function growl(msg, options, fn) {
       break;
     case 'Darwin-NotificationCenter':
       args.push(cmd.msg);
-      args.push(quote(msg));
+      var stringifiedMsg = quote(msg);
+      var escapedMsg = stringifiedMsg.replace(/\\n/g, '\n');
+      args.push(escapedMsg);
       if (options.title) {
         args.push(cmd.title);
         args.push(quote(options.title));


### PR DESCRIPTION
Hey, I'm wondering if you'd be interested in allowing \n to appear as actual line breaks for any of the platforms you're supporting.

Here's how the last example notification from test.js appears with these changes.

![Example of changes using test.js](https://f.cloud.github.com/assets/609078/1918008/9bd14d88-7daf-11e3-86db-8e2420e4970c.png)
