### PR TITLE
Add 'exec' option for custom notifiers

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -161,6 +161,14 @@ function growl(msg, options, fn) {
     , options = options || {}
     , fn = fn || function(){};
 
+  if (options.exec) {
+    cmd = {
+        type: "Custom"
+      , pkg: options.exec
+      , range: []
+    };
+  }
+
   // noop
   if (!cmd) return fn(new Error('growl not supported on this platform'));
   args = [cmd.pkg];
@@ -248,6 +256,16 @@ function growl(msg, options, fn) {
     case 'Windows':
       args.push(quote(msg));
       if (options.title) args.push(cmd.title + quote(options.title));
+      break;
+    case 'Custom':
+      args[0] = (function(origCommand) {
+        var message = options.title
+          ? options.title + ': ' + msg
+          : msg;
+        var command = origCommand.replace(/(^|[^%])%s/g, '$1' + quote(message));
+        if (command === origCommand) args.push(quote(message));
+        return command;
+      })(args[0]);
       break;
   }
 

--- a/test.js
+++ b/test.js
@@ -18,3 +18,6 @@ growl('Show pdf filesystem icon', { title: 'Use show()', image: 'article.pdf' })
 growl('here \' are \n some \\ characters that " need escaping', {}, function(error, stdout, stderr) {
   if (error !== null) throw new Error('escaping failed:\n' + stdout + stderr);
 })
+growl('Allow custom notifiers', { exec: 'echo %s' })
+growl('Allow custom notifiers', { title: 'test', exec: 'echo' })
+growl('Allow custom notifiers', { title: 'test', exec: 'echo %s' })


### PR DESCRIPTION
Pass in an 'exec' option to `growl()` to use a custom command for notifications. It will append the message to the command unless you include a `%s` in the command string which is expanded to the message. 'title' is expanded to a `Title:` prefix in the quoted message.

Also `%%s` will NOT expand but `%s` will (so it can be escaped if needed.

The hack isn't as clean as I'd like but it's kinda the way the original data structure was designed. Perhaps this one commit could segway to a more expressive API then it is at the moment.

To address issue #41 one could use this like so:

```
growl('test message', { exec: 'tmux display-message' });
```
