### PR TITLE
Add output for exec command tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -19,7 +19,13 @@ growl('Show pdf filesystem icon', { title: 'Use show()', image: 'article.pdf' })
 growl('here \' are \n some \\ characters that " need escaping', {}, function(error, stdout, stderr) {
   if (error !== null) throw new Error('escaping failed:\n' + stdout + stderr);
 })
-growl('Allow custom notifiers', { exec: 'echo %s' })
-growl('Allow custom notifiers', { title: 'test', exec: 'echo' })
-growl('Allow custom notifiers', { title: 'test', exec: 'echo %s' })
+growl('Allow custom notifiers', { exec: 'echo XXX %s' }, function(error, stdout, stderr) {
+  console.log(stdout);
+})
+growl('Allow custom notifiers', { title: 'test', exec: 'echo YYY' }, function(error, stdout, stderr) {
+  console.log(stdout);
+})
+growl('Allow custom notifiers', { title: 'test', exec: 'echo ZZZ %s' }, function(error, stdout, stderr) {
+  console.log(stdout);
+})
 growl('Open a URL', { url: 'https://npmjs.org/package/growl' });


### PR DESCRIPTION
The tests for the exec functionality would not output anything while using `echo`. This adds the callback to output (`console.log`) the `echo` output.
