### PR TITLE
Add icon feature for OSX

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -31,6 +31,7 @@ switch(os.type()) {
         , msg: '-message'
         , title: '-title'
         , subtitle: '-subtitle'
+        , icon: '-appIcon'
         , sound:  '-sound'
         , url: '-open'
         , priority: {
@@ -189,6 +190,9 @@ function growl(msg, options, fn) {
         flag = flag || ext && (image = ext) && 'icon'
         flag = flag || 'icon'
         args.push('--' + flag, quote(image))
+        break;
+      case 'Darwin-NotificationCenter':
+        args.push(cmd.icon, quote(image));
         break;
       case 'Linux':
         args.push(cmd.icon, quote(image));


### PR DESCRIPTION
This passes the icon option to terminal-notifier as appIcon to show an icon.

Thanks for this module!