### PR TITLE
Move eslint-plugin-node to devDependencies section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "devDependencies": {
     "eslint": "^4.2.0",
     "eslint-config-airbnb-base": "^11.2.0",
-    "eslint-plugin-import": "^2.7.0"
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-node": "^5.1.0"
   },
   "scripts": {
     "test": "node test.js",
@@ -24,8 +25,5 @@
   },
   "engines": {
     "node": ">=4.x"
-  },
-  "dependencies": {
-    "eslint-plugin-node": "^5.1.0"
   }
 }


### PR DESCRIPTION
`eslint-plugin-node` is a development dependency and should be in a `devDependency` section.

Right now installing `node-growl` from `npm` causes the following warning:

    npm WARN eslint-plugin-node@5.1.1 requires a peer of eslint@>=3.1.0 but none is installed. You must install peer dependencies yourself.

Related to #64.