### PR TITLE
69 Fix notifications on linux when using notify-send

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -272,13 +272,8 @@ function growl(msg, opts, callback) {
       }
       break;
     case 'Linux':
-      if (options.title) {
-        args.push(options.title);
-        args.push(cmd.msg);
-        args.push(msg.replace(/\\n/g, '\n'));
-      } else {
-        args.push(msg.replace(/\\n/g, '\n'));
-      }
+      if (options.title) args.push(options.title);
+      args.push(msg.replace(/\\n/g, '\n'));
       break;
     case 'Windows':
       args.push(msg.replace(/\\n/g, '\n'));

--- a/lib/growl.js
+++ b/lib/growl.js
@@ -308,6 +308,11 @@ function growl(msg, opts, callback) {
   let stderr = '';
   let error;
 
+  const now = new Date();
+  const timestamp = `${now.getHours()}:${now.getMinutes()}:${now.getSeconds()}.${now.getMilliseconds()}`
+
+  stderr += `[${timestamp}][node-growl] : Executed command '${cmdToExec}' with arguments '${args}'\n[stderr] : `;
+
   child.on('error', (err) => {
     console.error('An error occured.', err);
     error = err;

--- a/lib/growl.js
+++ b/lib/growl.js
@@ -86,7 +86,7 @@ function setupCmd() {
           type: 'Linux',
           pkg: 'notify-send',
           msg: '',
-          sticky: '-t 0',
+          sticky: '-t',
           icon: '-i',
           priority: {
             cmd: '-u',
@@ -214,6 +214,7 @@ function growl(msg, opts, callback) {
 
   // sticky
   if (options.sticky) args.push(cmd.sticky);
+  if (options.sticky && cmd.type === 'Linux') args.push('0');
 
   // priority
   if (options.priority) {


### PR DESCRIPTION
Hi,

I have added fixes for two issues when using notify-send on the linux platform. 
- The first issue is as reported in[ issue#69](https://github.com/tj/node-growl/issues/69)
- When using the sticky option with notify-send, it interprets `'-t 0'` as a single argument. To resolve that `'-t'` and `'0'` have to be sent separately. Executing the following command
`notify-send '-t 0' 'Email Client' '5 new emails'`
results in
`Cannot parse integer value “Email Client” for -t`
- I have also added a log of the command and arguments passed to `child_process.spawn` to the `stderr`. I feel it will save a bit of time for anyone who encounters an error while using node-growl.

This is my first contribution, if I have missed something obvious or not followed the protocol, I apologise for that and request your guidance.

Thanks!