### PR TITLE
Callback not receiving errors

### DIFF
--- a/lib/growl.js
+++ b/lib/growl.js
@@ -326,7 +326,7 @@ function growl(msg, opts, callback) {
     stderr += data;
   });
 
-  child.on('close', (code) => {
+  child.on('close', () => {
     if (typeof fn === 'function') {
       fn(error, stdout, stderr);
     }

--- a/lib/growl.js
+++ b/lib/growl.js
@@ -327,7 +327,7 @@ function growl(msg, opts, callback) {
   });
 
   child.on('close', (code) => {
-    error = error || code === 0 ? null : code;
+    error = error ? error : code === 0 ? null : code;
     if (typeof fn === 'function') {
       fn(error, stdout, stderr);
     }

--- a/lib/growl.js
+++ b/lib/growl.js
@@ -327,13 +327,11 @@ function growl(msg, opts, callback) {
   });
 
   child.on('close', (code) => {
-    error = error ? error : code === 0 ? null : code;
     if (typeof fn === 'function') {
       fn(error, stdout, stderr);
     }
   });
 }
-
 
 /**
  * Expose `growl`.

--- a/test.js
+++ b/test.js
@@ -17,7 +17,7 @@ growl('Show pdf filesystem icon', { image: 'article.pdf' }, function(){
 })
 growl('Show pdf filesystem icon', { title: 'Use show()', image: 'article.pdf' })
 growl('here \' are \n some \\ characters that " need escaping', {}, function(error, stdout, stderr) {
-  if (error !== null) throw new Error('escaping failed:\n' + stdout + stderr);
+  if (error) throw new Error('escaping failed:\n' + stdout + stderr);
 })
 growl('Allow custom notifiers', { exec: 'echo XXX %s' }, function(error, stdout, stderr) {
   console.log(stdout);


### PR DESCRIPTION
The callback was not being passed the error that was being thrown by node-growl. I changed the logic to first see if the error was set and if so pass that. If error is not set than resume the original logic of checking the code and returning null if it's 0 or the value of code if its greater than 0.

I wasn't sure if there was something that was relying on this logic, though there shouldn't be any cases now where the code would be greater than 0 and there not be an error.

This is my first PR, please let me know if I can provide any more details.